### PR TITLE
Add evm hash support

### DIFF
--- a/src/chaintypes.ts
+++ b/src/chaintypes.ts
@@ -1,5 +1,5 @@
-import { typesBundleDeprecated } from "moonbeam-types-bundle";
+import { typesBundlePre900 } from "moonbeam-types-bundle";
 
 export default {
-  typesBundle: typesBundleDeprecated
+  typesBundle: typesBundlePre900
 };

--- a/src/mappings/Transfers.ts
+++ b/src/mappings/Transfers.ts
@@ -109,7 +109,7 @@ async function createTransfer({
   element.timestamp = timestamp(event.block);
   element.blockNumber = blockNumber(event);
   if (event.extrinsic !== undefined) {
-    if (isEvmTransaction(event.extrinsic.extrinsic.method) && event.idx === 250 && event.extrinsic.extrinsic.hash.toString() === "0x52e14d272d378cee198b0774fa1e6fb7ccf3f16611e31c18defee37aa501c188") {
+    if (isEvmTransaction(event.extrinsic.extrinsic.method)) {
       const executedEvent = event.extrinsic.events.find(isEvmExecutedEvent)
       element.extrinsicHash = executedEvent?.event.data?.[2]?.toString() || event.extrinsic.extrinsic.hash.toString();
     } else {

--- a/src/mappings/Transfers.ts
+++ b/src/mappings/Transfers.ts
@@ -7,6 +7,8 @@ import {
   calculateFeeAsString,
   timestamp,
   getEventData,
+  isEvmTransaction,
+  isEvmExecutedEvent
 } from "./common";
 
 type TransferPayload = {
@@ -107,8 +109,14 @@ async function createTransfer({
   element.timestamp = timestamp(event.block);
   element.blockNumber = blockNumber(event);
   if (event.extrinsic !== undefined) {
-    element.extrinsicHash = event.extrinsic.extrinsic.hash.toString();
-    element.extrinsicIdx = event.extrinsic.idx;
+    if (isEvmTransaction(event.extrinsic.extrinsic.method) && event.idx === 250 && event.extrinsic.extrinsic.hash.toString() === "0x52e14d272d378cee198b0774fa1e6fb7ccf3f16611e31c18defee37aa501c188") {
+      const executedEvent = event.extrinsic.events.find(isEvmExecutedEvent)
+      element.extrinsicHash = executedEvent?.event.data?.[2]?.toString() || event.extrinsic.extrinsic.hash.toString();
+    } else {
+      element.extrinsicHash = event.extrinsic.extrinsic.hash.toString();
+    }
+
+    element.extrinsicIdx = event.extrinsic.idx;  
   }
 
   const transfer = {

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -32,6 +32,14 @@ export function isAssetTransfer(call: CallBase<AnyTuple>) : boolean {
     return call.section == "assets" && transferCalls.includes(call.method)
 }
 
+export function isEvmTransaction(call: CallBase<AnyTuple>): boolean {
+    return call.section === "ethereum" && call.method === "transact"
+}
+
+export function isEvmExecutedEvent(event: SubstrateEvent): boolean {
+    return event.event.section === 'ethereum' && event.event.method === "Executed"
+}
+
 export function isOrmlTransfer(call: CallBase<AnyTuple>) : boolean {
     return ormlSections.includes(call.section) && transferCalls.includes(call.method)
 }


### PR DESCRIPTION
Receive evm hash from third attribute `ethereum.Executed` event which generated by `ethereum.transact` call.