### PR TITLE
Adding restrictions for ipfs-unixfs

### DIFF
--- a/networks/acala/package.json
+++ b/networks/acala/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/altair/package.json
+++ b/networks/altair/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/astar/package.json
+++ b/networks/astar/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/basilisk/package.json
+++ b/networks/basilisk/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/bifrost/package.json
+++ b/networks/bifrost/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/bit-country/package.json
+++ b/networks/bit-country/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/calamari/package.json
+++ b/networks/calamari/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/centrifuge/package.json
+++ b/networks/centrifuge/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/clover/package.json
+++ b/networks/clover/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/crab-solochain/package.json
+++ b/networks/crab-solochain/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/crab/package.json
+++ b/networks/crab/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/edgeware/package.json
+++ b/networks/edgeware/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/efinity/package.json
+++ b/networks/efinity/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/encointer/package.json
+++ b/networks/encointer/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/equilibrium/package.json
+++ b/networks/equilibrium/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/hydra/package.json
+++ b/networks/hydra/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/integritee-solochain/package.json
+++ b/networks/integritee-solochain/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/integritee/package.json
+++ b/networks/integritee/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/interlay/package.json
+++ b/networks/interlay/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/karura/package.json
+++ b/networks/karura/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/khala/package.json
+++ b/networks/khala/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/kico/package.json
+++ b/networks/kico/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/kilt/package.json
+++ b/networks/kilt/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/kintsugi/package.json
+++ b/networks/kintsugi/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/kusama/package.json
+++ b/networks/kusama/package.json
@@ -24,5 +24,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/litmus/package.json
+++ b/networks/litmus/package.json
@@ -25,5 +25,8 @@
       "@subql/cli": "^0.21.0",
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/moonbeam/package.json
+++ b/networks/moonbeam/package.json
@@ -28,5 +28,8 @@
   },
   "exports": {
     "chaintypes": "./chaintypes.ts"
+  },
+  "resolutions": {
+    "ipfs-unixfs": "6.0.6"
   }
 }

--- a/networks/moonriver/package.json
+++ b/networks/moonriver/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/nodle-solochain/package.json
+++ b/networks/nodle-solochain/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/nodle/package.json
+++ b/networks/nodle/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/parallel-heiko/package.json
+++ b/networks/parallel-heiko/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/parallel/package.json
+++ b/networks/parallel/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/phala/package.json
+++ b/networks/phala/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./src/chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/picasso/package.json
+++ b/networks/picasso/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/polkadot/package.json
+++ b/networks/polkadot/package.json
@@ -24,5 +24,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/quartz/package.json
+++ b/networks/quartz/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/shadow/package.json
+++ b/networks/shadow/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/shiden/package.json
+++ b/networks/shiden/package.json
@@ -28,5 +28,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/statemine/package.json
+++ b/networks/statemine/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/statemint/package.json
+++ b/networks/statemint/package.json
@@ -25,5 +25,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.21.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/subsocial-solochain/package.json
+++ b/networks/subsocial-solochain/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/subsocial/package.json
+++ b/networks/subsocial/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/turing/package.json
+++ b/networks/turing/package.json
@@ -25,5 +25,8 @@
       "@subql/cli": "^0.21.0",
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/westend/package.json
+++ b/networks/westend/package.json
@@ -24,5 +24,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/westmint/package.json
+++ b/networks/westmint/package.json
@@ -24,5 +24,8 @@
       "@subql/types": "^0.14.0",
       "typescript": "^4.1.3",
       "@subql/cli": "^0.23.0"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/networks/zeitgeist/package.json
+++ b/networks/zeitgeist/package.json
@@ -29,5 +29,8 @@
     },
     "exports": {
       "chaintypes": "./chaintypes.ts"
+    },
+    "resolutions": {
+      "ipfs-unixfs": "6.0.6"
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "@subql/types": "^0.12.0",
     "typescript": "^4.1.3",
     "@subql/cli": "^0.16.2"
+  },
+  "resolutions": {
+    "ipfs-unixfs": "6.0.6"
   }
 }


### PR DESCRIPTION
As on SubQuery infrastructure has dependencies problem:
```
2022-05-04,18:35:10.1651689310
Cloning into '/data/subql'...
start to build package
Note: checking out 'c70967d691268976070a954cad46160d0aab88e2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at c70967d... Prepare to pull request to deploy branch (#102)
yarn install v1.22.17
info No lockfile found.
[1/4] Resolving packages...
warning @subql/cli > cli-ux@5.6.7: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
[2/4] Fetching packages...
error ipfs-unixfs@6.0.7: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.19.1"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Found incompatible module.
download dependencies failed
```
Example project:
https://project.subquery.network/project/nova-wallet/nova-wallet-moonriver

Was found fix for that:
https://zenn.dev/somasekimoto/articles/ba37c9bc53d26d