### PR TITLE
Crab-solochain indexer fixing

### DIFF
--- a/networks/crab-solochain/chaintypes.ts
+++ b/networks/crab-solochain/chaintypes.ts
@@ -1,6 +1,18 @@
 import { OverrideBundleType } from '@polkadot/types/types';
-import { typesBundleForPolkadotApps } from '@darwinia/types/mix';
+import { typesBundle } from '@darwinia/types/mix';
+
+
 
 export default {
-  typesBundle: typesBundleForPolkadotApps as OverrideBundleType
-};
+  types: {
+    ExposureT:{
+      ownRingBalance: "Compact<Balance>",
+      ownKtonBalance: "Compact<Balance>",
+      ownPower: "Power",
+      totalPower: "Power",
+      others: "Vec<IndividualExposure>"
+    },
+    Power: "u32"
+  },
+  typesBundle: typesBundle.spec
+}

--- a/networks/crab-solochain/project.yaml
+++ b/networks/crab-solochain/project.yaml
@@ -14,7 +14,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 3001
     mapping:
       file: ./dist/src/index.js
       handlers:


### PR DESCRIPTION
The problem is:

```javascript
2022-05-10 04:46:51        API/INIT: RPC methods not decorated: eth_feeHistory
{"level":"info","timestamp":"2022-05-10T04:46:53.220Z","pid":8,"hostname":"subquery-13236-indexer-deployment-7844546b96-5t85t","category":"subql-node","message":"Node started on port: 3000"}
2022-05-10 04:46:54        REGISTRY: Unknown signed extensions CheckEthRelayHeaderHash found, treating them as no-effect
{"level":"info","timestamp":"2022-05-10T04:46:59.474Z","pid":8,"hostname":"subquery-13236-indexer-deployment-7844546b96-5t85t","category":"fetch","message":"fetch block [3001,3015], total 15 blocks"}
2022-05-10 04:47:00        RPC-CORE: queryStorageAt(keys: Vec<StorageKey>, at?: BlockHash): Vec<StorageChangeSet>:: Unable to decode storage staking.erasStakersClipped: entry 0:: createType(ExposureT):: {"ownRingBalance":"Balance","ownKtonBalance":"Balance","ownPower":"Power","totalPower":"Power","others":"Vec<IndividualExposure>"}:: Decoded input doesn't match input, received 0x02286bee0080b2e60e80b2e60e00 (14 bytes), created 0x02286bee0080b2e60e80b2e60e00000000000000000000000000000000000000000000000000000000 (41 bytes)
2022-05-10 04:47:00             DRR: Unable to decode storage staking.erasStakersClipped: entry 0:: createType(ExposureT):: {"ownRingBalance":"Balance","ownKtonBalance":"Balance","ownPower":"Power","totalPower":"Power","others":"Vec<IndividualExposure>"}:: Decoded input doesn't match input, received 0x02286bee0080b2e60e80b2e60e00 (14 bytes), created 0x02286bee0080b2e60e80b2e60e00000000000000000000000000000000000000000000000000000000 (41 bytes)
{"level":"error","timestamp":"2022-05-10T04:47:00.339Z","pid":8,"hostname":"subquery-13236-indexer-deployment-7844546b96-5t85t","category":"fetch","payload":{"type":"error","name":"Error","message":"Unable to decode storage staking.erasStakersClipped: entry 0:: createType(ExposureT):: {\"ownRingBalance\":\"Balance\",\"ownKtonBalance\":\"Balance\",\"ownPower\":\"Power\",\"totalPower\":\"Power\",\"others\":\"Vec<IndividualExposure>\"}:: Decoded input doesn't match input, received 0x02286bee0080b2e60e80b2e60e00 (14 bytes), created 0x02286bee0080b2e60e80b2e60e00000000000000000000000000000000000000000000000000000000 (41 bytes)","stack":"Error: Unable to decode storage staking.erasStakersClipped: entry 0:: createType(ExposureT):: {\"ownRingBalance\":\"Balance\",\"ownKtonBalance\":\"Balance\",\"ownPower\":\"Power\",\"totalPower\":\"Power\",\"others\":\"Vec<IndividualExposure>\"}:: Decoded input doesn't match input, received 0x02286bee0080b2e60e80b2e60e00 (14 bytes), created 0x02286bee0080b2e60e80b2e60e00000000000000000000000000000000000000000000000000000000 (41 bytes)\n    at RpcCore._newType (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:477:13)\n    at RpcCore._formatStorageSetEntry (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:456:17)\n    at /usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:434:25\n    at Type.reduce (<anonymous>)\n    at RpcCore._formatStorageSet (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:433:17)\n    at /usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:407:58\n    at Array.map (<anonymous>)\n    at RpcCore._formatOutput (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:402:29)\n    at RpcCore._formatResult (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:222:27)\n    at callWithRegistry (/usr/local/lib/node_modules/@subql/node/node_modules/@polkadot/rpc-core/bundle.cjs:250:19)"},"message":"failed to index block at height 3001 handleNewEra([{\"phase\":{\"initialization\":null},\"event\":{\"index\":\"0x1004\",\"data\":[\"Authority\"]},\"topics\":[]}])"}
Close
```

As solution was tried to add the "ExposureT" type definition, as result was got the error:

```javascript
crab-solochain-subquery-node-1   | 2022-05-16T07:04:11.266Z <subql-node> INFO Node started on port: 3000 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.326Z <nestjs> INFO Starting Nest application... 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.339Z <nestjs> INFO AppModule dependencies initialized 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.339Z <nestjs> INFO ConfigureModule dependencies initialized 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.339Z <nestjs> INFO GraphqlModule dependencies initialized 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.345Z <subql-query> INFO Started playground at http://localhost:3000 
crab-solochain-graphql-engine-1  | 2022-05-16T07:04:11.708Z <nestjs> INFO Nest application successfully started 
crab-solochain-subquery-node-1   | 2022-05-16 07:04:12        REGISTRY: Unknown signed extensions CheckEthRelayHeaderHash found, treating them as no-effect
crab-solochain-subquery-node-1   | 2022-05-16T07:04:16.851Z <fetch> INFO fetch block [3001,3100], total 100 blocks 
crab-solochain-subquery-node-1   | 2022-05-16T07:04:28.499Z <fetch> ERROR failed to index block at height 3001 handleNewEra() TypeError: Cannot read properties of undefined (reading 'toBigInt')
crab-solochain-subquery-node-1 exited with code 1
crab-solochain-subquery-node-1   | 2022-05-16 07:04:32        API/INIT: RPC methods not decorated: balances_usableBalance, eth_feeHistory, fee_inProcessOrders, fee_marketFee, staking_powerOf
crab-solochain-subquery-node-1   | 2022-05-16T07:04:33.101Z <subql-node> INFO Node started on port: 3000 
crab-solochain-subquery-node-1   | 2022-05-16 07:04:34        REGISTRY: Unknown signed extensions CheckEthRelayHeaderHash found, treating them as no-effect
^CGracefully stopping... (press Ctrl+C again to force)
```

Any Ideas how we should fix that?