### PR TITLE
Update description for all projects

### DIFF
--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -7,11 +7,37 @@
 SCRIPT_PATH=$(dirname "$0")
 MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 
-SUBQUERY_TOKEN="NDA1NjA2NjA=j8zWM4C1BZS13G9mNmSI"
+SUBQUERY_TOKEN="NDA1NjA2NjA=HxySJFmehS6YBqn1onmQ"
 ORGANISATION="nova-wallet"
-DESCRIPTION="API for saturating Nova Wallet with information. Focuses on the following use cases: 1) Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics 2) Provide data for staking analytics"
 
-folders=($(ls ${MAIN_DIRECTORY}/networks))
+BASE_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+1) Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics </br>
+2) Provide data for staking analytics"
+
+DESCRIPTION_WITH_ORML="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+1) Provide complete operation history, including Transfers, Other extrinsics </br>
+2) Provide information about transfers with custom assets in network </br>
+for example to fetch custom assets history you can use that query: </br>
+query {
+    historyElements(first:5, filter:{assetTransfer:{notEqualTo:"null"}}){
+    nodes{
+      assetTransfer
+    }
+  }
+}
+"
+
+DESCRIPTION_WITH_ETH="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+1) Provide complete operation history, including Transfers, Other extrinsics </br>
+2) Provide information about ETH operation which store like usual extrinsic for account.
+"
+
+
+# folders=($(ls ${MAIN_DIRECTORY}/networks))
+folders='hydra'
 
 for item in ${folders[*]}
 do

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -7,42 +7,21 @@
 SCRIPT_PATH=$(dirname "$0")
 MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 
-SUBQUERY_TOKEN="NDA1NjA2NjA=HxySJFmehS6YBqn1onmQ"
+SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
 ORGANISATION="nova-wallet"
 
-REGULAR_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-- Provide operation history, including Transfers and Extrinsics
-"
+REGULAR_DESCRIPTION="regular"
 
-BASE_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-1) Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics </br>
-2) Provide data for staking analytics"
+BASE_DESCRIPTION="base"
 
-DESCRIPTION_WITH_ORML="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-1) Provide complete operation history, including Transfers, Other extrinsics </br>
-2) Provide information about transfers with custom assets in network </br>
-for example to fetch custom assets history you can use that query: </br>
-query {
-    historyElements(first:5, filter:{assetTransfer:{notEqualTo:"null"}}){
-    nodes{
-      assetTransfer
-    }
-  }
-}
-"
+DESCRIPTION_WITH_ORML="orml"
 
-DESCRIPTION_WITH_ETH="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-1) Provide complete operation history, including Transfers, Other extrinsics </br>
-2) Provide information about ETH operation which store like usual extrinsic for account.
-"
+DESCRIPTION_WITH_ETH="eth"
 
-ORML_PROJECTS=('karura')
+ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
 BASE_PROJECTS=('polkadot kusama westend')
 ETH_PROJECTS=('moonbeam moonriver astar shiden')
-ASSETS_PROJECTS=('statemine')
+ASSETS_PROJECTS=('statemine parallel parallel-heiko')
 
 folders=($(ls ${MAIN_DIRECTORY}/networks))
 
@@ -65,10 +44,9 @@ for item in ${folders[*]}; do
     DESCRIPTION=${DESCRIPTION_WITH_ETH}
   fi
 
-  printf ${item^}
-  echo ${DESCRIPTION}
+  echo ${item^}' - is a '${DESCRIPTION^^}' project'
   # $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key "nova-wallet-"$item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
 
 done
 
-printf "Done !"
+echo "Done !"

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -11,55 +11,49 @@ SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
 ORGANISATION="nova-wallet"
 
 
-BASE_DESCRIPTION="This project are indexing the blockchain and provides an API to retrieve information about the operations. It is used by the Nova Wallet project to fetching transaction history. </br>
-It can also be used for your own purposes too! </br>
+BASE_DESCRIPTION="Nova SubQuery project is indexing the blockchain and provides a convenient API for fetching operation history & analytics data. It is used by the Nova Wallet (novawallet.io), feel free to use this API for your app! 💖</br>
 </br>
-<mark>Make sure that you add filters and sorting rules to your queries</mark>.</p>
+<mark>Make sure that you add filters and sorting rules to your queries!</mark>.</p>
 </br>
-🗒  That project provide access to information about all transfers and extrinsics. To receive that information you can use: </br>
+Following API & datasource is supported:</br>
+</br>
+📚 Transfers and extrinsics (transactions). Both or either can be fetched, for example: </br>
 <code>query {historyElements{nodes{transfer extrinsic}}}</code>
 </br>"
 
-ORML_DESCRIPTION="</br>
-⚙️ This network also uses orml pallet for transfer assets and we proced it too! You can get the information about the orml assets transfer by using query like that:
-</br>
-<code>query {historyElements{nodes{assetTransfer}}}</code>
-</br>"
-
-ASSETS_DESCRIPTION="</br>
-⚙️ This network also uses Assets pallet for transfer assets and we proced it too! You can get the information about the Assets transfer by using query like that:
+MULTIASSET_DESCRIPTION="</br>
+✨ Transfer history for additional assets in the network (based on \"assets\"/\"ORML\" Substrate pallet):
 </br>
 <code>query {historyElements{nodes{assetTransfer}}}</code>
 </br>"
 
 STAKING_DESCRIPTION="</br>
-🪙 In that network has staking events on which you can get. For getting history of rewards you can use this one:
+🥞 Staking rewards history:
 </br>
 <code>query {historyElements{nodes{reward}}}</code>
 </br>
 </br>
-🥞 Also we are collecting information about accumulated staking which include rewards and slashes, you can request it by using:
+🎁 Total staking rewards for the desired acocunt:
 </br>
 <code>query {accumulatedRewards{nodes{id amount}}}</code>
 </br>"
 
 STAKING_ANALITIC="</br>
-🧾 As it is collected for rewards it also collected for user stake and you can get it by using this one:</br>
+📊 Current stake — returns bonded amount at certain block:</br>
 <code>query {accumulatedStakes{nodes{id amount}}}</code>
 </br> </br>
 
-👨‍🔧 For getting an information about validators you can request it by:
+👨‍🔧 Validators statistics:
 </br>
 <code>query {eraValidatorInfos{nodes{address era total own others}}}</code>
 </br> </br>
 
-📈 History about your stake changes is available by request:
+📈 Stake change history:
 </br>
 <code>query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}</code>
 </br>"
 
-ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
-ASSETS_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden')
+MULTIASSET_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden karura acala bifrost interlay kintsugi')
 HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
 HAS_STAKING_ANALYTIC=('polkadot kusama westend')
 
@@ -68,12 +62,8 @@ folders=($(ls ${MAIN_DIRECTORY}/networks))
 for item in ${folders[*]}; do
   DESCRIPTION=${BASE_DESCRIPTION}
 
-  if [[ " ${ORML_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION+=${ORML_DESCRIPTION}
-  fi
-
-  if [[ " ${ASSETS_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION+=${ASSETS_DESCRIPTION}
+  if [[ " ${MULTIASSET_PROJECTS[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION+=${MULTIASSET_DESCRIPTION}
   fi
 
   if [[ " ${HAS_STAKING[*]} " =~ " ${item} " ]]; then

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -10,13 +10,23 @@ MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
 ORGANISATION="nova-wallet"
 
-REGULAR_DESCRIPTION="regular"
+REGULAR_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+- Provide operation history, including Transfers and Extrinsics"
 
-BASE_DESCRIPTION="base"
+BASE_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+- Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics </br>
+- Provide data for staking analytics"
 
-DESCRIPTION_WITH_ORML="orml"
+DESCRIPTION_WITH_ORML="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+- Provide complete operation history, including Transfers, Other extrinsics </br>
+- Provide information about transfers with custom assets in network </br>"
 
-DESCRIPTION_WITH_ETH="eth"
+DESCRIPTION_WITH_ETH="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+- Provide complete operation history, including Transfers, Other extrinsics </br>
+- Provide information about ETH operation which store like usual extrinsic for account."
 
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
 BASE_PROJECTS=('polkadot kusama westend')

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -10,6 +10,10 @@ MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 SUBQUERY_TOKEN="NDA1NjA2NjA=HxySJFmehS6YBqn1onmQ"
 ORGANISATION="nova-wallet"
 
+REGULAR_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+- Provide operation history, including Transfers and Extrinsics
+"
+
 BASE_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
 Focuses on the following use cases: </br>
 1) Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics </br>
@@ -35,13 +39,36 @@ Focuses on the following use cases: </br>
 2) Provide information about ETH operation which store like usual extrinsic for account.
 "
 
+ORML_PROJECTS=('karura')
+BASE_PROJECTS=('polkadot kusama westend')
+ETH_PROJECTS=('moonbeam moonriver astar shiden')
+ASSETS_PROJECTS=('statemine')
 
-# folders=($(ls ${MAIN_DIRECTORY}/networks))
-folders='hydra'
+folders=($(ls ${MAIN_DIRECTORY}/networks))
 
-for item in ${folders[*]}
-do
-    $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key "nova-wallet-"$item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
+for item in ${folders[*]}; do
+  DESCRIPTION=${REGULAR_DESCRIPTION} #Set regular description for most of projects
+
+  if [[ " ${ORML_PROJECTS[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION=${DESCRIPTION_WITH_ORML}
+  fi
+
+  if [[ " ${BASE_PROJECTS[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION=${BASE_DESCRIPTION}
+  fi
+
+  if [[ " ${ETH_PROJECTS[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION=${DESCRIPTION_WITH_ETH}
+  fi
+
+  if [[ " ${ASSETS_PROJECTS[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION=${DESCRIPTION_WITH_ETH}
+  fi
+
+  printf ${item^}
+  echo ${DESCRIPTION}
+  # $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key "nova-wallet-"$item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
+
 done
 
 printf "Done !"

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -8,62 +8,44 @@ SCRIPT_PATH=$(dirname "$0")
 MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 
 SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
-ORGANISATION="stepanLav"
+ORGANISATION="nova-wallet"
 
 
-BASE_DESCRIPTION="Nova SubQuery project is indexing the blockchain and provides a convenient API for fetching operation history & analytics data. It is used by the Nova Wallet (novawallet.io)</br>
+BASE_DESCRIPTION="Nova SubQuery project is indexing the blockchain and provides a convenient API for fetching operation history & analytics data. It is used by the <a href=\"https://novawallet.io\">Nova Wallet</a>
 Feel free to use this API for your app! 💖</br>
-</br>
 <mark>Make sure that you add filters and sorting rules to your queries!</mark></br>
-</br>
 Following API & datasource is supported:
-</br>
-📚 Transfers and extrinsics (transactions). Both or either can be fetched, for example: </br>
+📚 Transfers and extrinsics (transactions). Both or either can be fetched, for example:
 <code>query {historyElements{nodes{transfer extrinsic}}}</code>
 </br>"
 
-MULTIASSET_DESCRIPTION="</br>
-✨ Transfer history for additional assets in the network (based on \"assets\"/\"ORML\" Substrate pallet):
-</br>
+MULTIASSET_DESCRIPTION="✨ Transfer history for additional assets in the network (based on \"assets\"/\"ORML\" Substrate pallet):
 <code>query {historyElements{nodes{assetTransfer}}}</code>
 </br>"
 
-STAKING_DESCRIPTION="</br>
-🥞 Staking rewards history:
-</br>
+STAKING_DESCRIPTION="🥞 Staking rewards history:
 <code>query {historyElements{nodes{reward}}}</code>
-</br>
-</br>
+
 🎁 Total staking rewards for the desired acocunt:
-</br>
 <code>query {accumulatedRewards{nodes{id amount}}}</code>
 </br>"
 
-STAKING_ANALITIC="</br>
-📊 Current stake — returns bonded amount:</br>
+STAKING_ANALITIC="📊 Current stake — returns bonded amount:
 <code>query {accumulatedStakes{nodes{id amount}}}</code>
-</br> </br>
 
 👨‍🔧 Validators statistics:
-</br>
 <code>query {eraValidatorInfos{nodes{address era total own others}}}</code>
-</br> </br>
 
 📈 Stake change history:
-</br>
 <code>query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}</code>
 </br>"
 
-# MULTIASSET_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden karura acala bifrost interlay kintsugi')
-# HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
-# HAS_STAKING_ANALYTIC=('polkadot kusama westend')
+MULTIASSET_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden karura acala bifrost interlay kintsugi')
+HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
+HAS_STAKING_ANALYTIC=('polkadot kusama westend')
 
-MULTIASSET_PROJECTS=('test')
-HAS_STAKING=('test-project fearless-test')
-HAS_STAKING_ANALYTIC=('test-project')
 
-# folders=($(ls ${MAIN_DIRECTORY}/networks))
-folders=('test test-project fearless-test')
+folders=($(ls ${MAIN_DIRECTORY}/networks))
 
 for item in ${folders[*]}; do
   DESCRIPTION=${BASE_DESCRIPTION}

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -44,7 +44,7 @@ for item in ${folders[*]}; do
     DESCRIPTION=${DESCRIPTION_WITH_ETH}
   fi
 
-  echo ${item^}' - is a '${DESCRIPTION^^}' project'
+  echo ${item^}' - is '${DESCRIPTION^^}' project'
   # $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key "nova-wallet-"$item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
 
 done

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -28,6 +28,11 @@ Focuses on the following use cases: </br>
 - Provide complete operation history, including Transfers, Other extrinsics </br>
 - Provide information about ETH operation which store like usual extrinsic for account."
 
+DESCRIPTION_WITH_ASSETS="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
+Focuses on the following use cases: </br>
+- Provide complete operation history, including Transfers, Other extrinsics </br>
+- Provide information about transfers with custom assets in network </br>"
+
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
 BASE_PROJECTS=('polkadot kusama westend')
 ETH_PROJECTS=('moonbeam moonriver astar shiden')
@@ -51,7 +56,7 @@ for item in ${folders[*]}; do
   fi
 
   if [[ " ${ASSETS_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_ETH}
+    DESCRIPTION=${DESCRIPTION_WITH_ASSETS}
   fi
 
   echo ${item^}' - is '${DESCRIPTION^^}' project'

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -8,14 +8,15 @@ SCRIPT_PATH=$(dirname "$0")
 MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 
 SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
-ORGANISATION="nova-wallet"
+ORGANISATION="stepanLav"
 
 
-BASE_DESCRIPTION="Nova SubQuery project is indexing the blockchain and provides a convenient API for fetching operation history & analytics data. It is used by the Nova Wallet (novawallet.io), feel free to use this API for your app! 💖</br>
+BASE_DESCRIPTION="Nova SubQuery project is indexing the blockchain and provides a convenient API for fetching operation history & analytics data. It is used by the Nova Wallet (novawallet.io)</br>
+Feel free to use this API for your app! 💖</br>
 </br>
-<mark>Make sure that you add filters and sorting rules to your queries!</mark>.</p>
+<mark>Make sure that you add filters and sorting rules to your queries!</mark></br>
 </br>
-Following API & datasource is supported:</br>
+Following API & datasource is supported:
 </br>
 📚 Transfers and extrinsics (transactions). Both or either can be fetched, for example: </br>
 <code>query {historyElements{nodes{transfer extrinsic}}}</code>
@@ -39,7 +40,7 @@ STAKING_DESCRIPTION="</br>
 </br>"
 
 STAKING_ANALITIC="</br>
-📊 Current stake — returns bonded amount at certain block:</br>
+📊 Current stake — returns bonded amount:</br>
 <code>query {accumulatedStakes{nodes{id amount}}}</code>
 </br> </br>
 
@@ -53,11 +54,16 @@ STAKING_ANALITIC="</br>
 <code>query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}</code>
 </br>"
 
-MULTIASSET_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden karura acala bifrost interlay kintsugi')
-HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
-HAS_STAKING_ANALYTIC=('polkadot kusama westend')
+# MULTIASSET_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden karura acala bifrost interlay kintsugi')
+# HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
+# HAS_STAKING_ANALYTIC=('polkadot kusama westend')
 
-folders=($(ls ${MAIN_DIRECTORY}/networks))
+MULTIASSET_PROJECTS=('test')
+HAS_STAKING=('test-project fearless-test')
+HAS_STAKING_ANALYTIC=('test-project')
+
+# folders=($(ls ${MAIN_DIRECTORY}/networks))
+folders=('test test-project fearless-test')
 
 for item in ${folders[*]}; do
   DESCRIPTION=${BASE_DESCRIPTION}

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -10,28 +10,30 @@ MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
 ORGANISATION="nova-wallet"
 
-REGULAR_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-- Provide operation history, including Transfers and Extrinsics"
+REGULAR_DESCRIPTION="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
+It can also be used for your own purposes too! </br>
+</br>
+Use historyElements entity to getting this information: </br>
+- Transfers that have been sent and received. Transfer parameter. </br>
+- Other operation that were submitted in blockchain. Extrinsic parameter."
 
-BASE_DESCRIPTION="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-- Provide complete operation history, including Transfers, Rewards/slashes, Other extrinsics </br>
-- Provide data for staking analytics"
+BASE_DESCRIPTION="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
+It can also be used for your own purposes too! </br>
+</br>
+Use historyElements entity to getting this information: </br>
+- Transfers that have been sent and received. Transfer parameter. </br>
+- Rewards and slashes for the staking activity. Reward parameter. </br>
+- Other operation that were submitted in blockchain. Extrinsic parameter. </br>
+</br>
+Use accumulatedRewards and accumulatedStake to getting accumulated information about about your stake."
 
-DESCRIPTION_WITH_ORML="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-- Provide complete operation history, including Transfers, Other extrinsics </br>
-- Provide information about transfers with custom assets in network </br>"
-
-DESCRIPTION_WITH_ETH="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-- Provide complete operation history, including Transfers, Other extrinsics </br>
-- Provide information about ETH operation which store like usual extrinsic for account."
-
-DESCRIPTION_WITH_ASSETS="Thats project provide an API for featching information from blockchain. It's using for the Nova Wallet project for showing transaction history </br>
-Focuses on the following use cases: </br>
-- Provide complete operation history, including Transfers, Other extrinsics </br>
-- Provide information about transfers with custom assets in network </br>"
+DESCRIPTION_WITH_CUSTOM_TOKENS="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
+It can also be used for your own purposes too! </br>
+</br>
+Use historyElements entity to getting this information: </br>
+- Transfers for the main asset in the network that have been sent and received. Transfer parameter. </br>
+- Transfers for additional assets which are also available in the network storing in another parameter - assetTransfer. </br>
+- Other operation that were submitted in blockchain. Extrinsic parameter."
 
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
 BASE_PROJECTS=('polkadot kusama westend')
@@ -44,7 +46,7 @@ for item in ${folders[*]}; do
   DESCRIPTION=${REGULAR_DESCRIPTION} #Set regular description for most of projects
 
   if [[ " ${ORML_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_ORML}
+    DESCRIPTION=${DESCRIPTION_WITH_CUSTOM_TOKENS} #ORML has no different with ASSETS pallet for subquery project
   fi
 
   if [[ " ${BASE_PROJECTS[*]} " =~ " ${item} " ]]; then
@@ -52,11 +54,11 @@ for item in ${folders[*]}; do
   fi
 
   if [[ " ${ETH_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_ETH}
+    DESCRIPTION=${BASE_DESCRIPTION}  #Use base descripiton as it provide the same information, as Polkadot/Kusama project.
   fi
 
   if [[ " ${ASSETS_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_ASSETS}
+    DESCRIPTION=${DESCRIPTION_WITH_CUSTOM_TOKENS} #ORML has no different with ASSETS pallet for subquery project
   fi
 
   echo ${item^}' - is '${DESCRIPTION^^}' project'

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -14,49 +14,48 @@ ORGANISATION="nova-wallet"
 BASE_DESCRIPTION="This project are indexing the blockchain and provides an API to retrieve information about the operations. It is used by the Nova Wallet project to fetching transaction history. </br>
 It can also be used for your own purposes too! </br>
 </br>
-⚠️  Make sure that you add filters and sorting rules to your queries  ⚠️
-</br>
+<mark>Make sure that you add filters and sorting rules to your queries</mark>.</p>
 </br>
 🗒  That project provide access to information about all transfers and extrinsics. To receive that information you can use: </br>
-query {historyElements{nodes{transfer extrinsic}}}
+<code>query {historyElements{nodes{transfer extrinsic}}}</code>
 </br>"
 
 ORML_DESCRIPTION="</br>
 ⚙️ This network also uses orml pallet for transfer assets and we proced it too! You can get the information about the orml assets transfer by using query like that:
 </br>
-query {historyElements{nodes{assetTransfer}}}
+<code>query {historyElements{nodes{assetTransfer}}}</code>
 </br>"
 
 ASSETS_DESCRIPTION="</br>
 ⚙️ This network also uses Assets pallet for transfer assets and we proced it too! You can get the information about the Assets transfer by using query like that:
 </br>
-query {historyElements{nodes{assetTransfer}}}
+<code>query {historyElements{nodes{assetTransfer}}}</code>
 </br>"
 
 STAKING_DESCRIPTION="</br>
 🪙 In that network has staking events on which you can get. For getting history of rewards you can use this one:
 </br>
-query {historyElements{nodes{reward}}}
+<code>query {historyElements{nodes{reward}}}</code>
 </br>
 </br>
 🥞 Also we are collecting information about accumulated staking which include rewards and slashes, you can request it by using:
 </br>
-query {accumulatedRewards{nodes{id amount}}}
+<code>query {accumulatedRewards{nodes{id amount}}}</code>
 </br>"
 
 STAKING_ANALITIC="</br>
 🧾 As it is collected for rewards it also collected for user stake and you can get it by using this one:</br>
-query {accumulatedStakes{nodes{id amount}}}
+<code>query {accumulatedStakes{nodes{id amount}}}</code>
 </br> </br>
 
 👨‍🔧 For getting an information about validators you can request it by:
 </br>
-query {eraValidatorInfos{nodes{address era total own others}}}
+<code>query {eraValidatorInfos{nodes{address era total own others}}}</code>
 </br> </br>
 
 📈 History about your stake changes is available by request:
 </br>
-query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}
+<code>query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}</code>
 </br>"
 
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -10,59 +10,82 @@ MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 SUBQUERY_TOKEN="${SUBQUERY_TOKEN}"
 ORGANISATION="nova-wallet"
 
-REGULAR_DESCRIPTION="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
-It can also be used for your own purposes too! </br>
-</br>
-Use historyElements entity to getting this information: </br>
-- Transfers that have been sent and received. Transfer parameter. </br>
-- Other operation that were submitted in blockchain. Extrinsic parameter."
 
-BASE_DESCRIPTION="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
+BASE_DESCRIPTION="This project are indexing the blockchain and provides an API to retrieve information about the operations. It is used by the Nova Wallet project to fetching transaction history. </br>
 It can also be used for your own purposes too! </br>
 </br>
-Use historyElements entity to getting this information: </br>
-- Transfers that have been sent and received. Transfer parameter. </br>
-- Rewards and slashes for the staking activity. Reward parameter. </br>
-- Other operation that were submitted in blockchain. Extrinsic parameter. </br>
+⚠️  Make sure that you add filters and sorting rules to your queries  ⚠️
 </br>
-Use accumulatedRewards and accumulatedStake to getting accumulated information about about your stake."
+</br>
+🗒  That project provide access to information about all transfers and extrinsics. To receive that information you can use: </br>
+query {historyElements{nodes{transfer extrinsic}}}
+</br>"
 
-DESCRIPTION_WITH_CUSTOM_TOKENS="This project provides an API to retrieve information from the blockchain. It is used by the Nova Wallet project to fetching transaction history. </br>
-It can also be used for your own purposes too! </br>
+ORML_DESCRIPTION="</br>
+⚙️ This network also uses orml pallet for transfer assets and we proced it too! You can get the information about the orml assets transfer by using query like that:
 </br>
-Use historyElements entity to getting this information: </br>
-- Transfers for the main asset in the network that have been sent and received. Transfer parameter. </br>
-- Transfers for additional assets which are also available in the network storing in another parameter - assetTransfer. </br>
-- Other operation that were submitted in blockchain. Extrinsic parameter."
+query {historyElements{nodes{assetTransfer}}}
+</br>"
+
+ASSETS_DESCRIPTION="</br>
+⚙️ This network also uses Assets pallet for transfer assets and we proced it too! You can get the information about the Assets transfer by using query like that:
+</br>
+query {historyElements{nodes{assetTransfer}}}
+</br>"
+
+STAKING_DESCRIPTION="</br>
+🪙 In that network has staking events on which you can get. For getting history of rewards you can use this one:
+</br>
+query {historyElements{nodes{reward}}}
+</br>
+</br>
+🥞 Also we are collecting information about accumulated staking which include rewards and slashes, you can request it by using:
+</br>
+query {accumulatedRewards{nodes{id amount}}}
+</br>"
+
+STAKING_ANALITIC="</br>
+🧾 As it is collected for rewards it also collected for user stake and you can get it by using this one:</br>
+query {accumulatedStakes{nodes{id amount}}}
+</br> </br>
+
+👨‍🔧 For getting an information about validators you can request it by:
+</br>
+query {eraValidatorInfos{nodes{address era total own others}}}
+</br> </br>
+
+📈 History about your stake changes is available by request:
+</br>
+query {stakeChanges{nodes{blockNumber extrinsicHash address amount accumulatedAmount type}}}
+</br>"
 
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
-BASE_PROJECTS=('polkadot kusama westend')
-ETH_PROJECTS=('moonbeam moonriver astar shiden')
-ASSETS_PROJECTS=('statemine parallel parallel-heiko westmint')
+ASSETS_PROJECTS=('statemine parallel parallel-heiko westmint moonbeam moonriver astar shiden')
+HAS_STAKING=('polkadot kusama westend moonbeam moonriver')
+HAS_STAKING_ANALYTIC=('polkadot kusama westend')
 
 folders=($(ls ${MAIN_DIRECTORY}/networks))
 
 for item in ${folders[*]}; do
-  DESCRIPTION=${REGULAR_DESCRIPTION} #Set regular description for most of projects
+  DESCRIPTION=${BASE_DESCRIPTION}
 
   if [[ " ${ORML_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_CUSTOM_TOKENS} #ORML has no different with ASSETS pallet for subquery project
-  fi
-
-  if [[ " ${BASE_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${BASE_DESCRIPTION}
-  fi
-
-  if [[ " ${ETH_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${BASE_DESCRIPTION}  #Use base descripiton as it provide the same information, as Polkadot/Kusama project.
+    DESCRIPTION+=${ORML_DESCRIPTION}
   fi
 
   if [[ " ${ASSETS_PROJECTS[*]} " =~ " ${item} " ]]; then
-    DESCRIPTION=${DESCRIPTION_WITH_CUSTOM_TOKENS} #ORML has no different with ASSETS pallet for subquery project
+    DESCRIPTION+=${ASSETS_DESCRIPTION}
   fi
 
-  echo ${item^}' - is '${DESCRIPTION^^}' project'
-  # $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key "nova-wallet-"$item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
+  if [[ " ${HAS_STAKING[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION+=${STAKING_DESCRIPTION}
+  fi
+
+  if [[ " ${HAS_STAKING_ANALYTIC[*]} " =~ " ${item} " ]]; then
+    DESCRIPTION+=${STAKING_ANALITIC}
+  fi
+
+  $MAIN_DIRECTORY/subquery --token ${SUBQUERY_TOKEN} project update --org ${ORGANISATION} --key $item --description "${DESCRIPTION}" --subtitle "Nova Wallet SubQuery project for ${item^} network"
 
 done
 

--- a/scripts/update_projects_description.sh
+++ b/scripts/update_projects_description.sh
@@ -21,7 +21,7 @@ DESCRIPTION_WITH_ETH="eth"
 ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
 BASE_PROJECTS=('polkadot kusama westend')
 ETH_PROJECTS=('moonbeam moonriver astar shiden')
-ASSETS_PROJECTS=('statemine parallel parallel-heiko')
+ASSETS_PROJECTS=('statemine parallel parallel-heiko westmint')
 
 folders=($(ls ${MAIN_DIRECTORY}/networks))
 


### PR DESCRIPTION
This PR changes update project description script for support different descriptions for some group of projects.
Now it is divided on:

ORML_PROJECTS=('karura acala bifrost interlay kintsugi')
BASE_PROJECTS=('polkadot kusama westend')
ETH_PROJECTS=('moonbeam moonriver astar shiden')
ASSETS_PROJECTS=('statemine parallel parallel-heiko westmint')
REGULAR - all other projects which not include in categories above