### PR TITLE
Fix for fee calculations

### DIFF
--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -90,8 +90,11 @@ export function calculateFeeAsString(extrinsic?: SubstrateExtrinsic, from: strin
         const withdrawFee = exportFeeFromBalancesWithdrawEvent(extrinsic, from)
 
         if (withdrawFee !== BigInt(0)) {
-            const feeRefund = exportFeeRefund(extrinsic, from)
-            return feeRefund ? (withdrawFee - feeRefund).toString() : withdrawFee.toString();
+            if (isEvmTransaction(extrinsic.extrinsic.method)){
+                const feeRefund = exportFeeRefund(extrinsic, from)
+                return feeRefund ? (withdrawFee - feeRefund).toString() : withdrawFee.toString();
+            }
+            return withdrawFee.toString()
         }
 
         let balancesFee = exportFeeFromBalancesDepositEvent(extrinsic)
@@ -101,7 +104,7 @@ export function calculateFeeAsString(extrinsic?: SubstrateExtrinsic, from: strin
         return totalFee.toString()
     } else {
         return BigInt(0).toString()
-    } 
+    }
 }
 
 export function getEventData(event: SubstrateEvent): GenericEventData {


### PR DESCRIPTION
Transaction fee for some extrinsics is calculated wrong.

Example of extrinsic:
https://polkadot.subscan.io/extrinsic/10388838-4
<details>
  <summary>Curl request</summary>

```
curl 'https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadot' \
  -H 'authority: api.subquery.network' \
  -H 'accept: application/json' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8,ru;q=0.7' \
  -H 'content-type: application/json' \
  -H 'origin: https://explorer.subquery.network' \
  -H 'sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-site' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36' \
  --data-raw '{"query":"query {\n   historyElements(\n    first:100, filter:{address:\n      {equalTo:\"15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu\"}\n      and: {blockNumber:{equalTo:10388838}}\n    }){\n    nodes{\n      blockNumber\n      extrinsic\n    }\n  }\n}","variables":null}' \
  --compressed
```

</details>

https://astar.subscan.io/extrinsic/1000005-60

<details>
  <summary>Curl request</summary>

```
curl 'https://api.subquery.network/sq/nova-wallet/nova-wallet-astar__bm92Y' \
  -H 'authority: api.subquery.network' \
  -H 'accept: application/json' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8,ru;q=0.7' \
  -H 'content-type: application/json' \
  -H 'origin: https://explorer.subquery.network' \
  -H 'sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-site' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36' \
  --data-raw '{"query":"query {\n   historyElements(\n    first:100, filter:{address:\n      {equalTo:\"aWZF2Hr22KQ9vR6LoeYVQw6amY8UfFcihrS6DVuSfeobvaZ\"}\n      and: {blockNumber:{equalTo:1000005}}\n    }){\n    nodes{\n      blockNumber\n      extrinsic\n    }\n  }\n}","variables":null}' \
  --compressed
```

</details>

It was added by [ETH transaction fee fix](https://github.com/nova-wallet/subquery-nova/pull/103/files#diff-1930d3be9a72767451466bf1d3a050be80f57e771e41b90dc23e7168cbfcd0c2R94)
and was fixed by adding check on EVM transaction