### PR TITLE
Adding parachain staking to Turing

### DIFF
--- a/networks/turing/project.yaml
+++ b/networks/turing/project.yaml
@@ -78,3 +78,8 @@ dataSources:
           filter:
             module: staking
             method: StakersElected
+        - handler: handleParachainRewarded
+          kind: substrate/EventHandler
+          filter:
+            module: parachainStaking
+            method: Rewarded


### PR DESCRIPTION
As on the parachain uses another events, was added special handler for Turing network.

Tested locally:

<img width="1624" alt="Screenshot 2022-06-06 at 16 39 07" src="https://user-images.githubusercontent.com/40560660/172171968-41639c16-4cf5-4159-a301-480d150ccea0.png">
