### PR TITLE
Adding Darwinia, Kapex, Kylin

### DIFF
--- a/chainTypes/kylinChainTypes.ts
+++ b/chainTypes/kylinChainTypes.ts
@@ -1,9 +1,6 @@
-import type { OverrideBundleDefinition } from '@polkadot/types/types';
+import { OverrideBundleType } from "@polkadot/types/types";
 
-// structs need to be in order
-/* eslint-disable sort-keys */
-
-const definitions: OverrideBundleDefinition = {
+const types = {
   types: [
     {
       // on all versions
@@ -26,6 +23,14 @@ const definitions: OverrideBundleDefinition = {
       }
     }
   ]
+}
+
+const typesBundle: OverrideBundleType = {
+  spec: {
+    "kylin": types,
+  },
 };
 
-export default definitions;
+export default {
+  typesBundle,
+};

--- a/chainTypes/kylinChainTypes.ts
+++ b/chainTypes/kylinChainTypes.ts
@@ -1,0 +1,31 @@
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      // on all versions
+      minmax: [0, undefined],
+      types: {
+        Address: 'MultiAddress',
+        LookupSource: 'MultiAddress',
+        DataRequest: {
+          para_id: 'Option<ParaId>',
+          account_id: 'Option<AccountId>',
+          requested_block_number: 'BlockNumber',
+          processed_block_number: 'Option<BlockNumber>',
+          requested_timestamp: 'u128',
+          processed_timestamp: 'Option<u128>',
+          payload: 'Text',
+          feed_name: 'Text',
+          is_query: 'bool',
+          url: 'Option<Text>'
+        }
+      }
+    }
+  ]
+};
+
+export default definitions;

--- a/darwinia.yaml
+++ b/darwinia.yaml
@@ -1,0 +1,51 @@
+specVersion: 1.0.0
+name: subquery-nova-pichiu
+version: 1.0.0
+runner:
+  node:
+    name: '@subql/node'
+    version: v1.9.1
+  query:
+    name: '@subql/query'
+    version: v1.5.0
+description: Nova SubQuery project
+repository: https://github.com/nova-wallet/subquery-nova
+schema:
+  file: ./schema.graphql
+network:
+  chainId: '0xe71578b37a7c799b0ab4ee87ffa6f059a6b98f71f06fb8c84a8d88013a548ad6'
+  endpoint: wss://parachain-rpc.darwinia.network
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 135000
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleHistoryElement
+          kind: substrate/CallHandler
+        - handler: handleParachainRewarded
+          kind: substrate/EventHandler
+          filter:
+            module: parachainStaking
+            method: Rewarded
+        - handler: handleTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: balances
+            method: Transfer
+        - handler: handleAssetTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: assets
+            method: Transferred
+        - handler: handleCurrencyTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: currencies
+            method: Transferred
+        - handler: handleTokenTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: tokens
+            method: Transfer

--- a/darwinia.yaml
+++ b/darwinia.yaml
@@ -18,7 +18,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 135000
+    startBlock: 1
     mapping:
       file: ./dist/index.js
       handlers:

--- a/ipfs-cids/.darwinia-cid
+++ b/ipfs-cids/.darwinia-cid
@@ -1,0 +1,1 @@
+QmStmFvHXsFatydRtcG3oCEbD7WfN7bUN3QqNVXkA1zPbU

--- a/ipfs-cids/.kapex-cid
+++ b/ipfs-cids/.kapex-cid
@@ -1,0 +1,1 @@
+QmPUvXZvY9zWY5r5o2t5tqvaqN5MJHj4zV57FyLr7qcwQt

--- a/ipfs-cids/.kylin-cid
+++ b/ipfs-cids/.kylin-cid
@@ -1,0 +1,1 @@
+QmYHx7mWUzdka5NFx2CkByin2RnVoQ5t8Ensn7CG7pNTKT

--- a/kapex.yaml
+++ b/kapex.yaml
@@ -18,7 +18,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 90000
     mapping:
       file: ./dist/index.js
       handlers:

--- a/kapex.yaml
+++ b/kapex.yaml
@@ -1,0 +1,51 @@
+specVersion: 1.0.0
+name: subquery-nova-pichiu
+version: 1.0.0
+runner:
+  node:
+    name: '@subql/node'
+    version: v1.9.1
+  query:
+    name: '@subql/query'
+    version: v1.5.0
+description: Nova SubQuery project
+repository: https://github.com/nova-wallet/subquery-nova
+schema:
+  file: ./schema.graphql
+network:
+  chainId: '0x7838c3c774e887c0a53bcba9e64f702361a1a852d5550b86b58cd73827fa1e1e'
+  endpoint: wss://k-ui.kapex.network
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 1
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleHistoryElement
+          kind: substrate/CallHandler
+        - handler: handleParachainRewarded
+          kind: substrate/EventHandler
+          filter:
+            module: parachainStaking
+            method: Rewarded
+        - handler: handleTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: balances
+            method: Transfer
+        - handler: handleAssetTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: assets
+            method: Transferred
+        - handler: handleCurrencyTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: currencies
+            method: Transferred
+        - handler: handleTokenTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: tokens
+            method: Transfer

--- a/kylin.yaml
+++ b/kylin.yaml
@@ -1,0 +1,53 @@
+specVersion: 1.0.0
+name: subquery-nova-pichiu
+version: 1.0.0
+runner:
+  node:
+    name: '@subql/node'
+    version: v1.9.1
+  query:
+    name: '@subql/query'
+    version: v1.5.0
+description: Nova SubQuery project
+repository: https://github.com/nova-wallet/subquery-nova
+schema:
+  file: ./schema.graphql
+network:
+  chainId: '0xf2584690455deda322214e97edfffaf4c1233b6e4625e39478496b3e2f5a44c5'
+  endpoint: wss://polkadot.kylin-node.co.uk
+  chaintypes:
+    file: ./dist/kylinChaintypes.js
+dataSources:
+  - name: main
+    kind: substrate/Runtime
+    startBlock: 107350
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handleHistoryElement
+          kind: substrate/CallHandler
+        - handler: handleParachainRewarded
+          kind: substrate/EventHandler
+          filter:
+            module: parachainStaking
+            method: Rewarded
+        - handler: handleTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: balances
+            method: Transfer
+        - handler: handleAssetTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: assets
+            method: Transferred
+        - handler: handleCurrencyTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: currencies
+            method: Transferred
+        - handler: handleTokenTransfer
+          kind: substrate/EventHandler
+          filter:
+            module: tokens
+            method: Transfer

--- a/kylin.yaml
+++ b/kylin.yaml
@@ -20,7 +20,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 107350
+    startBlock: 110700
     mapping:
       file: ./dist/index.js
       handlers:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "shidenChaintypes": "./chainTypes/shidenChaintypes.ts",
     "subsocialChaintypes": "./chainTypes/subsocialChaintypes.ts",
     "zeitgeistChaintypes": "./chainTypes/zeitgeistChaintypes.ts",
-    "ternoaChaintypes": "./chainTypes/ternoaChaintypes.ts"
+    "ternoaChaintypes": "./chainTypes/ternoaChaintypes.ts",
+    "kylinChaintypes": "./chainTypes/kylinChainTypes.ts"
   },
   "resolutions": {
     "ipfs-unixfs": "6.0.6"


### PR DESCRIPTION
This PR adds new networks for SubQuery indexer:

- Darwinia
- Kapex
- Kylin

Kylin and Kapex have no archived node so that it was deployed from the current storage block number.

[Adding](https://github.com/nova-wallet/nova-utils/pull/845) to the nova-utils