### PR TITLE
fix CNAME file replacements

### DIFF
--- a/.github/workflows/get_projects_status.yaml
+++ b/.github/workflows/get_projects_status.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0/4 * * *'
   workflow_dispatch:
+  pull_request:
+    
 
 env:
  SUBQUERY_TOKEN: ${{ secrets.SUBQUERY_TOKEN }}

--- a/.github/workflows/get_projects_status.yaml
+++ b/.github/workflows/get_projects_status.yaml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 0/4 * * *'
   workflow_dispatch:
-  pull_request:
-    
 
 env:
  SUBQUERY_TOKEN: ${{ secrets.SUBQUERY_TOKEN }}

--- a/.github/workflows/get_projects_status.yaml
+++ b/.github/workflows/get_projects_status.yaml
@@ -22,6 +22,11 @@ jobs:
       - name: Generate table
         run: python ./scripts/python_scripts/generate_network_status.py
 
+      - uses: actions/checkout@v2
+        with:
+          branch: gh-pages
+          path: gh-pages
+
       - name: Deploy report to Github Pages
         uses: peaceiris/actions-gh-pages@v2
         env:

--- a/.github/workflows/get_projects_status.yaml
+++ b/.github/workflows/get_projects_status.yaml
@@ -26,8 +26,11 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          branch: gh-pages
+          ref: gh-pages
           path: gh-pages
+
+      - name: Copy table to gh-pages
+        run: mv ./gh-pages-temp/README.md ./gh-pages/README.md
 
       - name: Deploy report to Github Pages
         uses: peaceiris/actions-gh-pages@v2

--- a/scripts/python_scripts/generate_network_status.py
+++ b/scripts/python_scripts/generate_network_status.py
@@ -188,14 +188,14 @@ def remove_hex_prefix(hex_string):
 
 if __name__ == '__main__':
 
-    dir_name = 'gh-pages'
+    dir_name = 'gh-pages-temp'
     try:
         os.makedirs(dir_name)
         print("Directory ", dir_name,  " Created ")
     except FileExistsError:
         print("Directory ", dir_name,  " already exists")
 
-    with open("./gh-pages/README.md", "w") as f:
+    with open("./gh-pages-temp/README.md", "w") as f:
         f.write(readme.render(
             dapps_table=generate_networks_list()
         ))


### PR DESCRIPTION
This PR fixes a problem where after redeploying gh-pages the previous [CNAME](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain) file was replaced